### PR TITLE
Allow top-level launch-form sections and coexisting inputs/categories/sections

### DIFF
--- a/client/schemas/blueprint-spec2-schema.json
+++ b/client/schemas/blueprint-spec2-schema.json
@@ -1521,16 +1521,14 @@
                     "items": {
                         "$ref": "#/definitions/LaunchFormCategoryObject"
                     }
+                },
+                "sections": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/LaunchFormSectionObject"
+                    }
                 }
             },
-            "oneOf": [
-                {
-                    "required": ["inputs"]
-                },
-                {
-                    "required": ["categories"]
-                }
-            ],
             "title": "LaunchForm Object"
         },
         "LaunchFormInputObject": {
@@ -1616,6 +1614,10 @@
                     "type": "string",
                     "description": "The display name of the category"
                 },
+                "description": {
+                    "type": "string",
+                    "description": "Descriptive text shown under the category"
+                },
                 "icon": {
                     "type": "string",
                     "description": "Icon name for the category"
@@ -1657,6 +1659,10 @@
                 "name": {
                     "type": "string",
                     "description": "The display name of the section"
+                },
+                "description": {
+                    "type": "string",
+                    "description": "Descriptive text shown under the section"
                 },
                 "icon": {
                     "type": "string",


### PR DESCRIPTION
## Problem

Editing a **working** Torque blueprint in the VS Code extension produced two blocking `yaml-schema` warnings on `customization.launch-form`:

- `Missing property "inputs"` — LaunchForm Object
- `Property sections is not allowed`

The blueprint launches and renders correctly in Torque; the JSON schema in `client/schemas/blueprint-spec2-schema.json` was simply behind the product.

## Root cause

The schema modeled launch-form input customization as **exactly one of** `inputs` or `categories` (a `oneOf`), and only allowed `sections` **nested inside a category**. In reality the launch form is more flexible:

- `sections` can be declared **directly at the top level** of `launch-form` — they render into the default inputs category.
- `inputs`, `categories`, and `sections` can **all coexist** at the top level, alongside `steps`.
- Sections and categories both support a `description` field, which the schema didn't declare (so it would also throw `additionalProperties` errors once `sections` was allowed).

## Changes

All in `client/schemas/blueprint-spec2-schema.json`:

1. **`LaunchFormObject`** — add a top-level `sections` array (reusing the existing `LaunchFormSectionObject` definition, identical to how `categories` already nests sections) and **remove the `oneOf`**. `steps`, `inputs`, `categories`, and `sections` are now all independently optional and freely composable.
2. **`LaunchFormSectionObject`** — add optional `description`.
3. **`LaunchFormCategoryObject`** — add optional `description` (parallel to sections).

No new definitions were introduced; the top-level `sections` reuse `LaunchFormSectionObject`.

## Validation

Confirmed against a real blueprint that uses `steps` + `inputs` + `categories` + `sections` simultaneously (with `description` on sections) — both warnings clear. File parses as valid JSON.